### PR TITLE
Tarea #1955 - Añadido soporte para pre-tickets.

### DIFF
--- a/Lib/Tickets/BaseTicket.php
+++ b/Lib/Tickets/BaseTicket.php
@@ -55,6 +55,11 @@ abstract class BaseTicket
         return base64_encode($body);
     }
 
+    protected static function getLines(ModelClass $model)
+    {
+        return $model->lines ?? $model->getLines();
+    }
+
     protected static function getReceipts(ModelClass $model, TicketPrinter $printer): string
     {
         $paid = 0;
@@ -321,7 +326,7 @@ abstract class BaseTicket
         static::$escpos->setTextSize($printer->font_size, $printer->font_size);
 
         // añadimos las líneas
-        $lines = $model->getLines();
+        $lines = self::getLines($model);
         static::printLines($printer, $lines);
 
         foreach (static::getSubtotals($model, $lines) as $item) {

--- a/Lib/Tickets/Gift.php
+++ b/Lib/Tickets/Gift.php
@@ -39,7 +39,7 @@ class Gift extends Normal
         static::$escpos->text(static::sanitize($th) . "\n");
         static::$escpos->text($printer->getDashLine() . "\n");
 
-        foreach ($model->getLines() as $line) {
+        foreach (self::getLines($model) as $line) {
             $td = '';
             if ($printer->print_lines_quantity) {
                 $td .= sprintf("%5s", $line->cantidad) . ' ';


### PR DESCRIPTION
[Tarea #1955](https://facturascripts.com/roadmap/1955)

Esta modificación es necesario para añadir compatibilidad al imprimir un modelo que no está guardado en la base de datos, por lo que no se pueden obtener las líneas, y las líneas van incluidas en el propio modelo del documento.