### PR TITLE
Implementación impresión de logo

### DIFF
--- a/Controller/SendTicket.php
+++ b/Controller/SendTicket.php
@@ -155,6 +155,7 @@ class SendTicket extends Controller
         $tempTicket = $tickets[0];
         $base64Data = $tempTicket->body;
         $rawData = base64_decode($base64Data);
+        $previewBody = $tempTicket->previewbody ?? '';
                 
         // Restaura la longitud de línea original.
         $printer->linelen = $originalPaperWidth;
@@ -177,6 +178,7 @@ class SendTicket extends Controller
             'ok' => true,
             'data' => $hexData,
             'encoding' => 'hex',
+            'previewBody' => $previewBody,
         ];
         $this->response->setContent(json_encode($payload));
     }

--- a/Lib/GdEscposImageWrapper.php
+++ b/Lib/GdEscposImageWrapper.php
@@ -1,0 +1,55 @@
+<?php
+namespace FacturaScripts\Plugins\Tickets\Lib;
+
+use Mike42\Escpos\GdEscposImage;
+use Mike42\Escpos\EscposImage;
+
+/**
+ * Esta clase tiene el simple propósito de actuar como wrapper y modificar el método por defecto
+ * para que se acepte tanto un recurso GD (PHP 7) como un objeto GdImage (PHP 8).
+ * 
+ * (Este es un bug causado por la propia librería escpos-php al no actualizarse para adaptarse a las nuevas 
+ * versiones de gd y malinterpretar los objetos de gd como si no fueran objetos gd.)
+ */
+class GdEscposImageWrapper extends GdEscposImage
+{
+    /**
+     * Acepta tanto resource GD (PHP 7) como objeto GdImage (PHP 8).
+     *
+     * @param mixed $im Recurso/objeto GD válido
+     * @throws \Exception Si no es un recurso/objeto GD o si falta la extensión
+     */
+    public function readImageFromGdResource($im)
+    {
+        // Inicio lineas modificadas
+        $isGd = is_resource($im) || (class_exists('GdImage') && $im instanceof \GdImage);
+        if (!$isGd) {
+            // Fin lineas modificadas
+            throw new \Exception("Failed to load image: expected GD resource or GdImage.");
+        } elseif (!EscposImage::isGdLoaded()) {
+            throw new \Exception(__FUNCTION__ . " requires 'gd' extension.");
+        }
+
+        /* Make a string of 1's and 0's */
+        $imgHeight = imagesy($im);
+        $imgWidth  = imagesx($im);
+        $imgData   = str_repeat("\0", $imgHeight * $imgWidth);
+
+        for ($y = 0; $y < $imgHeight; $y++) {
+            for ($x = 0; $x < $imgWidth; $x++) {
+                /* Faster to average channels, blend alpha and negate the image here than via filters (tested!) */
+                $cols = imagecolorsforindex($im, imagecolorat($im, $x, $y));
+                // 1 for white, 0 for black, ignoring transparency
+                $greyness = (int)(($cols['red'] + $cols['green'] + $cols['blue']) / 3) >> 7;
+                // 1 for black, 0 for white, taking into account transparency
+                $black = (1 - $greyness) >> ($cols['alpha'] >> 6);
+                $imgData[$y * $imgWidth + $x] = $black;
+            }
+        }
+
+        $this->setImgWidth($imgWidth);
+        $this->setImgHeight($imgHeight);
+        $this->setImgData($imgData);
+    }
+}
+

--- a/Lib/PrintableImageManager.php
+++ b/Lib/PrintableImageManager.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Clase encargada de obtener una imágen y crear una copia apta para imprimir.
+ * 
+ * Generalmente lo que realiza es bajar el tamaño hasta que ocupe 384x384 (tamaño generalmente correcto para impresión)
+ * 
+ * Si la imagen tiene un aspect ratio diferente se hace más pequeña hasta caber en 384x384 sin cambiar el aspect ratio propio de la imágen.
+ * 
+ * También se aplica un filtro leve de cambio de color
+ * 
+ * Y después cambia a monocolor o 1 bit de color (blanco y negro)
+ * 
+ * @author Abderrahim Darghal Belkacemi
+*/
+
+namespace FacturaScripts\Plugins\Tickets\Lib;
+
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Plugins\Tickets\Lib\GdEscposImageWrapper;
+use Mike42\Escpos\GdEscposImage;
+
+class PrintableImageManager
+{
+
+    const MAX_WIDTH = 384;
+    const MAX_HEIGHT = 384;
+    const OUTPUT_IMAGE_PATH = "nigger";
+
+    /**
+     * Crea una copia de la imagen pasada por argumento con el formato adecuado para la impresión
+     * y la guarda en public (sobreescribe la imagen si ya existe en public)
+     * 
+     * Devuelve falso si el formato de imagen no es soportado o GdEscposImage si existe la imagen
+     * 
+     * @param string $imagePath Ruta de la imagen
+     * @return GdEscposImage | bool
+     */
+    static public function createPrintableImage($imagePath): GdEscposImage | bool
+    {
+        // Cargar imagen con GD y redimensionar a 384x384 manteniendo aspect ratio (letterboxing)
+        $ext = strtolower(pathinfo($imagePath, PATHINFO_EXTENSION));
+        $src = null;
+        switch ($ext) {
+            case 'png':
+                $src = @imagecreatefrompng($imagePath);
+                break;
+            case 'jpg':
+            case 'jpeg':
+                $src = @imagecreatefromjpeg($imagePath);
+                break;
+            case 'gif':
+                $src = @imagecreatefromgif($imagePath);
+                break;
+            case 'bmp':
+                if (function_exists('imagecreatefrombmp')) {
+                    $src = @imagecreatefrombmp($imagePath);
+                }
+                break;
+        }
+
+        if (!$src) {
+            return false;
+        }
+
+        $dst = imagecreatetruecolor(self::MAX_WIDTH, self::MAX_HEIGHT);
+
+        // Mantener canal alfa si existe, rellenando fondo blanco para coherencia con térmica
+        imagealphablending($dst, false);
+        imagesavealpha($dst, true);
+        $white = imagecolorallocatealpha($dst, 255, 255, 255, 0);
+        imagefilledrectangle($dst, 0, 0, self::MAX_WIDTH, self::MAX_HEIGHT, $white);
+
+        // Calcular escalado manteniendo proporción, sin ampliar si es más pequeño
+        $srcW = imagesx($src);
+        $srcH = imagesy($src);
+        $scale = min(self::MAX_WIDTH / $srcW, self::MAX_HEIGHT / $srcH, 1.0);
+        $newW = (int) floor($srcW * $scale);
+        $newH = (int) floor($srcH * $scale);
+        $dstX = (int) floor((self::MAX_WIDTH - $newW) / 2);
+        $dstY = (int) floor((self::MAX_HEIGHT - $newH) / 2);
+
+        imagecopyresampled(
+            $dst,
+            $src,
+            $dstX,
+            $dstY,
+            0,
+            0,
+            $newW,
+            $newH,
+            $srcW,
+            $srcH
+        );
+        imagedestroy($src);
+
+        // Preparar para impresión térmica: escala de grises + más contraste y leve oscurecido
+        if (function_exists('imagefilter')) {
+            @imagefilter($dst, IMG_FILTER_GRAYSCALE);
+            @imagefilter($dst, IMG_FILTER_CONTRAST, -20); // valores negativos aumentan contraste
+            @imagefilter($dst, IMG_FILTER_BRIGHTNESS, -10); // oscurecer ligeramente para marcar mejor
+        }
+        // Opcional: un ligero "sharpen" para resaltar bordes
+        if (function_exists('imageconvolution')) {
+            $sharpen = [
+                [-1, -1, -1],
+                [-1, 16, -1],
+                [-1, -1, -1],
+            ];
+            // Divisor 8 suaviza el efecto a un nivel moderado
+            @imageconvolution($dst, $sharpen, 8, 0);
+        }
+
+        // Convertir a 1-bit (blanco/negro) con la misma lógica que usa escpos-php (GdEscposImage)
+        $bw = imagecreate(self::MAX_WIDTH, self::MAX_HEIGHT); // imagen indexada (paleta) para limitar colores a 2
+        $whiteIdx = imagecolorallocate($bw, 255, 255, 255);
+        $blackIdx = imagecolorallocate($bw, 0, 0, 0);
+        imagefilledrectangle($bw, 0, 0, self::MAX_WIDTH, self::MAX_HEIGHT, $whiteIdx);
+        for ($y = 0; $y < self::MAX_HEIGHT; $y++) {
+            for ($x = 0; $x < self::MAX_WIDTH; $x++) {
+                $cols = imagecolorsforindex($dst, imagecolorat($dst, $x, $y));
+                // Igual a GdEscposImage: promedio canales, umbral 128 y mezcla de alpha
+                $greyness = (int)(($cols['red'] + $cols['green'] + $cols['blue']) / 3) >> 7; // 1 blanco, 0 negro (ignorando alpha)
+                $blackBit = (1 - $greyness) >> ($cols['alpha'] >> 6); // 1 negro, 0 blanco (considerando alpha)
+                imagesetpixel($bw, $x, $y, $blackBit ? $blackIdx : $whiteIdx);
+            }
+        }
+
+        // guardar el output con GD según la extensión (ya 1-bit visualmente)
+        $outExt = strtolower(pathinfo(self::OUTPUT_IMAGE_PATH, PATHINFO_EXTENSION));
+        if ($outExt === '') {
+            stderr("Error: Debes indicar extensión en el archivo de salida (png|jpg|gif|bmp).\n");
+        } else {
+            $saved = false;
+            switch ($outExt) {
+                case 'png':
+                    $saved = @imagepng($bw, self::OUTPUT_IMAGE_PATH, 6);
+                    break;
+                case 'jpg':
+                case 'jpeg':
+                    $saved = @imagejpeg($bw, self::OUTPUT_IMAGE_PATH, 90);
+                    break;
+                case 'gif':
+                    $saved = @imagegif($bw, self::OUTPUT_IMAGE_PATH);
+                    break;
+                case 'bmp':
+                    if (function_exists('imagebmp')) {
+                        $saved = @imagebmp($bw, self::OUTPUT_IMAGE_PATH, true);
+                    }
+                    break;
+            }
+            if ($saved) {
+                echo "Imagen procesada (1-bit) guardada en: {OUTPUT_IMAGE_PATH}\n";
+            } else {
+                stderr("No se pudo guardar la imagen en '{OUTPUT_IMAGE_PATH}'. Extensión no soportada o error de escritura.\n");
+            }
+        }
+
+        // Pasar recurso GD 1-bit al objeto EscposImage basado en GD
+        $img = new GdEscposImageWrapper("", false);
+        $img->readImageFromGdResource($bw);
+        // Limpiar recursos GD, datos ya están en $img
+        imagedestroy($dst);
+        imagedestroy($bw);
+
+        return $img;
+
+        // Imprimir centrado
+        // $printer->setJustification(Printer::JUSTIFY_CENTER);
+        // // Preferir GS ( L ) raster graphics; fallback a ESC *
+        // $printer->bitImageColumnFormat($img);
+    }
+}

--- a/Lib/PrintableImageManager.php
+++ b/Lib/PrintableImageManager.php
@@ -132,6 +132,10 @@ class PrintableImageManager
             }
         }
 
+        // Hacer el color blanco transparente para previsualización (mejor estética)
+        // En imágenes indexadas funciona con imagecolortransparent y se preserva en PNG
+        @imagecolortransparent($bw, $whiteIdx);
+
         // Guardar salida en carpeta pública (ruta estática y formato PNG)
         self::saveToPublic($bw);
 

--- a/Lib/Tickets/BaseTicket.php
+++ b/Lib/Tickets/BaseTicket.php
@@ -39,6 +39,9 @@ abstract class BaseTicket
     /** @var array */
     protected static $lines;
 
+    /** @var string */
+    protected static $preview = '';
+
     private static $openDrawer = true;
 
     abstract public static function print(ModelClass $model, TicketPrinter $printer, User $user, ?Agente $agent = null): bool;
@@ -57,14 +60,18 @@ abstract class BaseTicket
     {
         // dejamos espacio
         static::$escpos->feed(4);
+        // añadimos al preview líneas en blanco equivalentes
+        static::$preview .= "\n\n\n\n";
 
         // abrimos el cajón
         if (static::$openDrawer) {
             static::$escpos->pulse();
+            static::$preview .= "[PULSE]\n";
         }
 
         // cortamos el papel
         static::$escpos->cut();
+        static::$preview .= "[CUT]\n";
 
         // devolvemos los comandos de impresión
         $body = static::$escpos->getPrintConnector()->getData();
@@ -302,6 +309,20 @@ abstract class BaseTicket
         static::$escpos = new Printer(static::$connector);
         static::$connector->clear();
         static::$escpos->initialize();
+        // inicial para previsualización
+        static::$preview = "[INIT]\n";
+    }
+
+    protected static function text(string $text): void
+    {
+        // Escribimos al ESC/POS y al preview (en claro)
+        static::$escpos->text($text);
+        static::$preview .= $text;
+    }
+
+    public static function getPreview(): string
+    {
+        return static::$preview ?? '';
     }
 
     protected static function printLines(TicketPrinter $printer, array $lines): void
@@ -333,8 +354,8 @@ abstract class BaseTicket
             return;
         }
 
-        static::$escpos->text(static::sanitize($th) . "\n");
-        static::$escpos->text($printer->getDashLine() . "\n");
+        static::text(static::sanitize($th) . "\n");
+        static::text($printer->getDashLine() . "\n");
 
         foreach ($lines as $line) {
             $td = '';
@@ -388,11 +409,11 @@ abstract class BaseTicket
                 $td .= "\n";
             }
 
-            static::$escpos->text(static::sanitize($td) . "\n");
-            static::$escpos->text(static::getTrazabilidad($line, $width));
+            static::text(static::sanitize($td) . "\n");
+            static::text(static::getTrazabilidad($line, $width));
         }
 
-        static::$escpos->text($printer->getDashLine() . "\n");
+        static::text($printer->getDashLine() . "\n");
     }
 
     protected static function sanitize(?string $txt): string
@@ -433,15 +454,15 @@ abstract class BaseTicket
                 . sprintf("%10s", Tools::number($item['taxbase'])) . "\n"
                 . sprintf("%" . ($printer->linelen - 11) . "s", $item['tax']) . " "
                 . sprintf("%10s", Tools::number($item['taxamount']));
-            static::$escpos->text(static::sanitize($text) . "\n");
+            static::text(static::sanitize($text) . "\n");
 
             if ($item['taxsurcharge']) {
                 $text = sprintf("%" . ($printer->linelen - 11) . "s", "RE " . $item['taxsurchargep']) . " "
                     . sprintf("%10s", Tools::number($item['taxsurcharge']));
-                static::$escpos->text(static::sanitize($text) . "\n");
+                static::text(static::sanitize($text) . "\n");
             }
         }
-        static::$escpos->text($printer->getDashLine() . "\n");
+        static::text($printer->getDashLine() . "\n");
 
         // añadimos los totales
         $text = sprintf("%" . ($printer->linelen - 11) . "s", static::$i18n->trans('total')) . " "
@@ -456,16 +477,16 @@ abstract class BaseTicket
                 . sprintf("%10s", Tools::number($model->tpv_cambio)) . "\n";
         }
 
-        static::$escpos->text(static::sanitize($text) . "\n\n");
+        static::text(static::sanitize($text) . "\n\n");
 
         // añadimos las formas de pago
         if ($printer->print_payment_methods) {
-            static::$escpos->text(static::sanitize(static::getPaymentMethods($model, $printer)));
+            static::text(static::sanitize(static::getPaymentMethods($model, $printer)));
         }
 
         // añadimos los recibos
         if ($printer->print_invoice_receipts && $model->modelClassName() === 'FacturaCliente') {
-            static::$escpos->text(static::sanitize(static::getReceipts($model, $printer)));
+            static::text(static::sanitize(static::getReceipts($model, $printer)));
         }
     }
 
@@ -476,7 +497,7 @@ abstract class BaseTicket
         // añadimos el pie de página
         if ($printer->footer) {
             static::$escpos->setJustification(Printer::JUSTIFY_CENTER);
-            static::$escpos->text("\n" . static::sanitize($printer->footer) . "\n");
+            static::text("\n" . static::sanitize($printer->footer) . "\n");
             static::$escpos->setJustification(Printer::JUSTIFY_LEFT);
         }
     }
@@ -499,13 +520,18 @@ abstract class BaseTicket
                 if ($img !== false) {
                     static::$escpos->bitImageColumnFormat($img);
                     // static::$escpos->feed();
+                    // añadimos una pista de imagen para el preview usando la imagen pública generada
+                    $publicUrl = PrintableImageManager::getPublicImageUrl();
+                    if (!empty($publicUrl)) {
+                        static::$preview .= '[IMG:' . $publicUrl . "]\n";
+                    }
                 } else {
                     // Fallback si no se ha podido crear la imagen imprimible
-                    static::$escpos->text(static::sanitize('no se ha podido imprimir la imagen') . "\n");
+                    static::text(static::sanitize('no se ha podido imprimir la imagen') . "\n");
                 }
             } else {
                 // Fallback si no hay logo configurado pero se ha activado imprimir logo
-                static::$escpos->text(static::sanitize('sin logo seleccionado') . "\n");
+                static::text(static::sanitize('sin logo seleccionado') . "\n");
             }
 
             static::$escpos->setJustification(Printer::JUSTIFY_LEFT);
@@ -519,50 +545,50 @@ abstract class BaseTicket
 
         // imprimimos el nombre corto de la empresa
         if ($printer->print_comp_shortname) {
-            static::$escpos->text(static::sanitize($company->nombrecorto) . "\n");
+            static::text(static::sanitize($company->nombrecorto) . "\n");
             static::$escpos->setTextSize($printer->head_font_size, $printer->head_font_size);
 
             // imprimimos el nombre de la empresa
-            static::$escpos->text(static::sanitize($company->nombre) . "\n");
+            static::text(static::sanitize($company->nombre) . "\n");
         } else {
             // imprimimos el nombre de la empresa
-            static::$escpos->text(static::sanitize($company->nombre) . "\n");
+            static::text(static::sanitize($company->nombre) . "\n");
             static::$escpos->setTextSize($printer->head_font_size, $printer->head_font_size);
         }
 
         static::$escpos->setJustification();
 
         // imprimimos la dirección de la empresa
-        static::$escpos->text(static::sanitize($company->direccion) . "\n");
-        static::$escpos->text(static::sanitize("CP: " . $company->codpostal . ', ' . $company->ciudad) . "\n");
-        static::$escpos->text(static::sanitize($company->tipoidfiscal . ': ' . $company->cifnif) . "\n\n");
+        static::text(static::sanitize($company->direccion) . "\n");
+        static::text(static::sanitize("CP: " . $company->codpostal . ', ' . $company->ciudad) . "\n");
+        static::text(static::sanitize($company->tipoidfiscal . ': ' . $company->cifnif) . "\n\n");
 
         if ($printer->print_comp_tlf) {
             if (false === empty($company->telefono1) && false === empty($company->telefono2)) {
-                static::$escpos->text(static::sanitize($company->telefono1 . ' / ' . $company->telefono2) . "\n");
+                static::text(static::sanitize($company->telefono1 . ' / ' . $company->telefono2) . "\n");
             } elseif (false === empty($company->telefono1)) {
-                static::$escpos->text(static::sanitize($company->telefono1) . "\n");
+                static::text(static::sanitize($company->telefono1) . "\n");
             } elseif (false === empty($company->telefono2)) {
-                static::$escpos->text(static::sanitize($company->telefono2) . "\n");
+                static::text(static::sanitize($company->telefono2) . "\n");
             }
         }
 
         // imprimimos el título del documento
-        static::$escpos->text(static::sanitize($title) . "\n");
+        static::text(static::sanitize($title) . "\n");
 
         static::setHeaderTPV($model, $printer);
 
         // si es un documento de venta
         // imprimimos la fecha y el cliente
         if (in_array($model->modelClassName(), ['PresupuestoCliente', 'PedidoCliente', 'AlbaranCliente', 'FacturaCliente'])) {
-            static::$escpos->text(static::sanitize(static::$i18n->trans('date') . ': ' . $model->fecha . ' ' . $model->hora) . "\n");
-            static::$escpos->text(static::sanitize(static::$i18n->trans('customer') . ': ' . $model->nombrecliente) . "\n\n");
+            static::text(static::sanitize(static::$i18n->trans('date') . ': ' . $model->fecha . ' ' . $model->hora) . "\n");
+            static::text(static::sanitize(static::$i18n->trans('customer') . ': ' . $model->nombrecliente) . "\n\n");
         }
 
         // añadimos la cabecera
         if ($printer->head) {
             static::$escpos->setJustification(Printer::JUSTIFY_CENTER);
-            static::$escpos->text(static::sanitize($printer->head) . "\n\n");
+            static::text(static::sanitize($printer->head) . "\n\n");
             static::$escpos->setJustification();
         }
     }
@@ -577,7 +603,7 @@ abstract class BaseTicket
             return;
         }
 
-        static::$escpos->text(
+        static::text(
             static::sanitize(static::$i18n->trans('pos-terminal') . ': ' . $model->getTerminal()->name) . "\n"
         );
     }

--- a/Lib/Tickets/BaseTicket.php
+++ b/Lib/Tickets/BaseTicket.php
@@ -17,6 +17,7 @@ use FacturaScripts\Dinamic\Model\PrePago;
 use FacturaScripts\Dinamic\Model\TicketPrinter;
 use FacturaScripts\Dinamic\Model\User;
 use FacturaScripts\Dinamic\Model\AttachedFile;
+use FacturaScripts\Plugins\Tickets\Lib\PrintableImageManager;
 use Mike42\Escpos\PrintConnectors\DummyPrintConnector;
 use Mike42\Escpos\Printer;
 
@@ -482,75 +483,36 @@ abstract class BaseTicket
 
     protected static function setHeader(ModelClass $model, TicketPrinter $printer, string $title): void
     {
-        // obtenemos los datos de la empresa
-        $company = $model->getCompany();
-
-        // imprimimos el logotipo de la empresa si procede
+        // imprimimos el logotipo si procede
         if ($printer->print_stored_logo) {
             static::$escpos->setJustification(Printer::JUSTIFY_CENTER);
 
-            $printed = false;
-            $hasCompanyLogo = !empty($company->idlogo);
-            try {
-                if (!empty($company->idlogo)) {
-                    $file = new AttachedFile();
-                    if ($file->load($company->idlogo)) {
-                        $path = $file->getFullPath();
-                        if (is_string($path) && !empty($path) && is_file($path) && is_readable($path)) {
-                            // Comprobamos extensiones de imagen disponibles
-                            if (!extension_loaded('gd') && !extension_loaded('imagick')) {
-                                Tools::log()->warning('tickets: no GD/Imagick extensions available for image printing');
-                            }
-
-                            // Intentamos obtener información de la imagen
-                            $imgInfo = @getimagesize($path);
-                            if (false === $imgInfo) {
-                                Tools::log()->warning('tickets: unable to read image info for logo at ' . $path);
-                            } else {
-                                $mime = $imgInfo['mime'] ?? 'unknown';
-                                Tools::log()->notice('tickets: trying to print logo ' . basename($path) . ' (' . ($imgInfo[0] ?? '?') . 'x' . ($imgInfo[1] ?? '?') . ', ' . $mime . ')');
-                            }
-
-                            // Intentamos imprimir la imagen usando la librería ESC/POS
-                            try {
-                                $img = \Mike42\Escpos\EscposImage::load($path, false);
-                                // Método clásico
-                                static::$escpos->bitImage($img);
-                                static::$escpos->feed();
-                                $printed = true;
-                            } catch (\Throwable $e1) {
-                                Tools::log()->warning('tickets: bitImage() failed for logo: ' . $e1->getMessage());
-                                // Alternativa para versiones con graphics()
-                                try {
-                                    $img = \Mike42\Escpos\EscposImage::load($path, false);
-                                    static::$escpos->graphics($img);
-                                    static::$escpos->feed();
-                                    $printed = true;
-                                } catch (\Throwable $e2) {
-                                    Tools::log()->error('tickets: graphics() failed for logo: ' . $e2->getMessage());
-                                    $printed = false;
-                                }
-                            }
-                        } else {
-                            Tools::log()->warning('tickets: logo file not accessible (path invalid/unreadable): ' . var_export($path, true));
-                        }
-                    } else {
-                        Tools::log()->warning('tickets: attached logo file could not be loaded (id ' . $company->idlogo . ')');
-                    }
-                }
-            } catch (\Throwable $ignored) {
-                $printed = false;
-                Tools::log()->error('tickets: exception while preparing logo for printing: ' . $ignored->getMessage());
+            // Usar únicamente el logo configurado en la impresora
+            $path = '';
+            $file = new AttachedFile();
+            if (!empty($printer->idlogo) && $file->load((int) $printer->idlogo)) {
+                $path = $file->getFullPath();
             }
 
-            // Si no se pudo imprimir el logo real y existe un logo asignado, añadimos una nota informativa
-            if (!$printed && $hasCompanyLogo) {
-                static::$escpos->setJustification(Printer::JUSTIFY_CENTER);
-                static::$escpos->text(static::sanitize('(logo asignado no impreso)') . "\n");
+            if (is_string($path) && is_file($path) && is_readable($path)) {
+                $img = PrintableImageManager::createPrintableImage($path);
+                if ($img !== false) {
+                    static::$escpos->bitImageColumnFormat($img);
+                    // static::$escpos->feed();
+                } else {
+                    // Fallback si no se ha podido crear la imagen imprimible
+                    static::$escpos->text(static::sanitize('no se ha podido imprimir la imagen') . "\n");
+                }
+            } else {
+                // Fallback si no hay logo configurado pero se ha activado imprimir logo
+                static::$escpos->text(static::sanitize('sin logo seleccionado') . "\n");
             }
 
             static::$escpos->setJustification(Printer::JUSTIFY_LEFT);
         }
+
+        // obtenemos los datos de la empresa
+        $company = $model->getCompany();
 
         // establecemos el tamaño de la fuente
         static::$escpos->setTextSize($printer->title_font_size, $printer->title_font_size);

--- a/Lib/Tickets/Gift.php
+++ b/Lib/Tickets/Gift.php
@@ -38,8 +38,8 @@ class Gift extends Normal
             return;
         }
 
-        static::$escpos->text(static::sanitize($th) . "\n");
-        static::$escpos->text($printer->getDashLine() . "\n");
+        static::text(static::sanitize($th) . "\n");
+        static::text($printer->getDashLine() . "\n");
 
         foreach (self::getLines($model) as $line) {
             $td = '';
@@ -53,9 +53,9 @@ class Gift extends Normal
                 $td .= sprintf("%-" . $width . "s", substr($line->descripcion, 0, $width));
             }
 
-            static::$escpos->text(static::sanitize($td) . "\n");
+            static::text(static::sanitize($td) . "\n");
         }
 
-        static::$escpos->text($printer->getDashLine() . "\n");
+        static::text($printer->getDashLine() . "\n");
     }
 }

--- a/Lib/Tickets/Normal.php
+++ b/Lib/Tickets/Normal.php
@@ -6,8 +6,6 @@
 namespace FacturaScripts\Plugins\Tickets\Lib\Tickets;
 
 use FacturaScripts\Core\Template\ModelClass;
-use FacturaScripts\Core\Tools;
-
 use FacturaScripts\Dinamic\Model\Agente;
 use FacturaScripts\Dinamic\Model\Ticket;
 use FacturaScripts\Dinamic\Model\TicketPrinter;
@@ -32,6 +30,7 @@ class Normal extends BaseTicket
         static::setBody($model, $printer);
         static::setFooter($model, $printer);
         $ticket->body = static::getBody();
+        $ticket->previewbody = static::getPreview();
         $ticket->base64 = true;
         $ticket->appversion = 1;
 

--- a/Lib/Tickets/PaymentReceipt.php
+++ b/Lib/Tickets/PaymentReceipt.php
@@ -32,6 +32,7 @@ class PaymentReceipt extends BaseTicket
         static::setBody($model, $printer);
         static::setFooter($model, $printer);
         $ticket->body = static::getBody();
+        $ticket->previewbody = static::getPreview();
         $ticket->base64 = true;
         $ticket->appversion = 1;
 
@@ -43,20 +44,20 @@ class PaymentReceipt extends BaseTicket
         static::$escpos->setTextSize($printer->font_size, $printer->font_size);
 
         // imprimimos los datos del recibo
-        static::$escpos->text(static::sanitize(static::$i18n->trans('invoice') . ': ' . $model->codigofactura) . "\n");
-        static::$escpos->text(static::sanitize(static::$i18n->trans('customer') . ': ' . $model->getInvoice()->nombrecliente) . "\n");
-        static::$escpos->text(static::sanitize(static::$i18n->trans('receipt') . ': ' . $model->numero) . "\n");
-        static::$escpos->text(static::sanitize(static::$i18n->trans('date') . ': ' . $model->fecha) . "\n\n");
-        static::$escpos->text(static::sanitize(static::$i18n->trans('amount') . ': ' . $model->importe . ' ' . $model->coddivisa) . "\n");
+        static::text(static::sanitize(static::$i18n->trans('invoice') . ': ' . $model->codigofactura) . "\n");
+        static::text(static::sanitize(static::$i18n->trans('customer') . ': ' . $model->getInvoice()->nombrecliente) . "\n");
+        static::text(static::sanitize(static::$i18n->trans('receipt') . ': ' . $model->numero) . "\n");
+        static::text(static::sanitize(static::$i18n->trans('date') . ': ' . $model->fecha) . "\n\n");
+        static::text(static::sanitize(static::$i18n->trans('amount') . ': ' . $model->importe . ' ' . $model->coddivisa) . "\n");
 
         if ($model->pagado) {
-            static::$escpos->text(static::sanitize(static::$i18n->trans('payment-date') . ': ' . $model->fechapago) . "\n\n");
+            static::text(static::sanitize(static::$i18n->trans('payment-date') . ': ' . $model->fechapago) . "\n\n");
         } else {
-            static::$escpos->text(static::sanitize(static::$i18n->trans('expiration') . ': ' . $model->vencimiento) . "\n\n");
+            static::text(static::sanitize(static::$i18n->trans('expiration') . ': ' . $model->vencimiento) . "\n\n");
         }
 
         if ($model->observaciones) {
-            static::$escpos->text(static::sanitize(static::$i18n->trans('observations') . ': ' . $model->observaciones) . "\n\n");
+            static::text(static::sanitize(static::$i18n->trans('observations') . ': ' . $model->observaciones) . "\n\n");
         }
     }
 }

--- a/Model/Ticket.php
+++ b/Model/Ticket.php
@@ -31,6 +31,11 @@ class Ticket extends ModelClass
      * @var string
      */
     public $body;
+    
+    /**
+     * @var string
+     */
+    public $previewbody;
 
     /**
      * @var string
@@ -105,6 +110,7 @@ class Ticket extends ModelClass
     public function save(): bool
     {
         $this->body = $this->base64 ? $this->body : $this->sanitize($this->body);
+        $this->previewbody = $this->sanitize($this->previewbody);
         $this->title = Tools::noHtml($this->title);
 
         if ($this->printed && empty($this->printdelay)) {

--- a/Model/TicketPrinter.php
+++ b/Model/TicketPrinter.php
@@ -10,6 +10,7 @@ use FacturaScripts\Core\Template\ModelTrait;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Model\ApiAccess;
 use FacturaScripts\Dinamic\Model\ApiKey;
+use FacturaScripts\Dinamic\Model\AttachedFile;
 
 /**
  * @author Carlos Garcia Gomez      <carlos@facturascripts.com>
@@ -107,6 +108,9 @@ class TicketPrinter extends ModelClass
 
     /** @var bool */
     public $print_stored_logo;
+
+    /** @var int|null */
+    public $idlogo;
 
     /** @var int */
     public $title_font_size;
@@ -218,6 +222,19 @@ class TicketPrinter extends ModelClass
         $this->head = Tools::noHtml($this->head);
         $this->name = Tools::noHtml($this->name);
         $this->opencommand = Tools::noHtml($this->opencommand);
+
+        // Validate assigned logo: only allow GD-friendly images (jpeg, png, gif)
+        if (!empty($this->idlogo)) {
+            $file = new AttachedFile();
+            if ($file->load((int)$this->idlogo)) {
+                // Server-side guard to accepted formats
+                if (!in_array($file->mimetype, ['image/jpeg', 'image/png', 'image/gif'], true)) {
+                    $this->idlogo = null;
+                }
+            } else {
+                $this->idlogo = null;
+            }
+        }
 
         return parent::save();
     }

--- a/Table/tickets_docs.xml
+++ b/Table/tickets_docs.xml
@@ -18,6 +18,10 @@
         <type>text</type>
     </column>
     <column>
+        <name>previewbody</name>
+        <type>text</type>
+    </column>
+    <column>
         <name>codagente</name>
         <type>character varying(10)</type>
     </column>

--- a/Table/tickets_printers.xml
+++ b/Table/tickets_printers.xml
@@ -135,6 +135,10 @@
         <default>false</default>
     </column>
     <column>
+        <name>idlogo</name>
+        <type>integer</type>
+    </column>
+    <column>
         <name>title_font_size</name>
         <type>integer</type>
         <default>2</default>
@@ -146,5 +150,9 @@
     <constraint>
         <name>ca_tickets_printers_api</name>
         <type>FOREIGN KEY (idapikey) REFERENCES api_keys (id) ON DELETE RESTRICT ON UPDATE CASCADE</type>
+    </constraint>
+    <constraint>
+        <name>ca_tickets_printers_attached_files</name>
+        <type>FOREIGN KEY (idlogo) REFERENCES attached_files (idfile) ON DELETE SET NULL ON UPDATE CASCADE</type>
     </constraint>
 </table>

--- a/View/Modal/PrintTicketModal.html.twig
+++ b/View/Modal/PrintTicketModal.html.twig
@@ -554,95 +554,38 @@ Este segundo modal es parecido al primero pero dedicado ya al funcionamiento de 
     const LSK_PRINTER_ID = 'selectedQzPrinterId';
     const LSK_TICKET_PAPER_WIDTH = 'ticketPaperWidth';
 
-    function generateHtmlPreview(escposData) {
+    // Nuevo renderizador de previsualización basado en flags simples en previewBody
+    function escapeHtml(text) {
+        return text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    function renderTicketPreview(previewText) {
+        if (!previewText) return `<p class=\"text-muted text-center\" style=\"white-space: normal;\">{{ trans('select-printer-and-load-preview') }}</p>`;
         let html = '';
-        let buffer = '';
-        let justification = 'left';
-        let isDoubleStrike = false;
-
-        function flushBuffer() {
-            if (buffer.length > 0) {
-                let style = `text-align: ${justification}; margin: 0; padding: 0;`;
-                if (isDoubleStrike) {
-                    style += ' font-size: 1.2em; font-weight: bold;';
-                }
-                // Escape HTML characters from the buffer content
-                const safeBuffer = buffer.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-                html += `<div style="${style}">${safeBuffer.replace(/ /g, '&nbsp;')}</div>`;
-            }
-            buffer = '';
-        }
-
-        for (let i = 0; i < escposData.length; i++) {
-            const char = escposData[i];
-            const next = i + 1 < escposData.length ? escposData[i + 1] : '';
-            const next2 = i + 2 < escposData.length ? escposData[i + 2] : '';
-
-            // Printer Initialize
-            if (char === '\x1b' && next === '@') {
-                flushBuffer();
+        const lines = previewText.split('\n');
+        for (const raw of lines) {
+            const line = raw.trimEnd();
+            if (line === '[INIT]') {
                 html += translatedSnippets.init;
-                i++; // Consume '@'
-                continue;
-            }
-
-            // Justification
-            if (char === '\x1b' && next === 'a') {
-                flushBuffer();
-                if (next2 === '\x00') justification = 'left';
-                else if (next2 === '\x01') justification = 'center';
-                else if (next2 === '\x02') justification = 'right';
-                i += 2;
-                continue;
-            }
-
-            // Character Size
-            if (char === '\x1d' && next === '!') {
-                flushBuffer();
-                isDoubleStrike = (next2 !== '\x00');
-                i += 2;
-                continue;
-            }
-
-            // Cut Paper
-            if (char === '\x1d' && next === 'V') {
-                flushBuffer();
+            } else if (line === '[CUT]') {
                 html += translatedSnippets.cut;
-                const mode = next2;
-                i += 2; // Skip 'V' and 'mode'
-                if ((mode === 'A' || mode === 'B' || mode === '\x41' || mode === '\x42') && i < escposData.length) {
-                    i++; // Skip 'n' for modes A and B
-                }
-                continue;
-            }
-
-            // Pulse Drawer
-            if (char === '\x1b' && next === 'p') {
-                flushBuffer();
+            } else if (line === '[PULSE]') {
                 html += translatedSnippets.pulse;
-                i += 4; // Skips p, m, t1, t2
-                continue;
-            }
-
-            // Print and feed n lines
-            if (char === '\x1b' && next === 'd') {
-                flushBuffer();
-                const n = i + 2 < escposData.length ? escposData.charCodeAt(i + 2) : 0;
-                for (let j = 0; j < n; j++) {
-                    html += '<div>&nbsp;</div>'; // Represents a blank line
-                }
-                i += 2; // consume 'd' and 'n'
-                continue;
-            }
-
-            if (char === '\n') {
-                flushBuffer();
-            } else if (char >= ' ') { // Append printable characters
-                buffer += char;
+            } else if (line.startsWith('[IMG:') && line.endsWith(']')) {
+                const url = line.substring(5, line.length - 1);
+                const safeUrl = escapeHtml(url);
+                html += `<div style=\"text-align:center; margin:8px 0;\"><img src=\"${safeUrl}\" alt=\"ticket-image\" style=\"display:inline-block; max-width:100%; image-rendering: pixelated;\"/></div>`;
+            } else if (line.length === 0) {
+                html += '<div>&nbsp;</div>';
+            } else {
+                html += `<div style=\"text-align:left; margin:0; padding:0;\">${escapeHtml(line).replace(/ /g, '&nbsp;')}</div>`;
             }
         }
-        flushBuffer(); // Flush any remaining text
-
         return html;
     }
 
@@ -679,10 +622,10 @@ Este segundo modal es parecido al primero pero dedicado ya al funcionamiento de 
             success: function(response) {
                 console.log('Response from server:', response);
                 if (response && response.ok && response.data && response.data.length > 0) {
-                    // Backend devuelve HEX; guardamos HEX para impresión con formato visible (\xHH por byte)
-                    receivedESCPOSTData = response.data.replace(/(..)/g, 'x$1');
-                    // modifica receivedESCPOSTData para que añada x a cada dos carácteres para que se vean como hex
-                    const previewHtml = generateHtmlPreview(receivedESCPOSTData);
+                    // Guardamos HEX crudo para impresión
+                    receivedESCPOSTData = response.data;
+                    // Renderizamos preview simple desde previewBody
+                    const previewHtml = renderTicketPreview(response.previewBody || '');
                     $('#ticketPreviewContainer').html(previewHtml);
                     $('#printTicketButton').prop('disabled', false);
                     showModalAlert(`{{ trans('ticket-ready-to-print') }}`, 'success', 5000, 'modalPrintAlert', 'modalPrintAlertMessage');

--- a/View/Modal/PrintTicketModal.html.twig
+++ b/View/Modal/PrintTicketModal.html.twig
@@ -679,8 +679,10 @@ Este segundo modal es parecido al primero pero dedicado ya al funcionamiento de 
             success: function(response) {
                 console.log('Response from server:', response);
                 if (response && response.ok && response.data && response.data.length > 0) {
-                    receivedESCPOSTData = response.data;
-                    const previewHtml = generateHtmlPreview(response.data);
+                    // Backend devuelve HEX; guardamos HEX para impresión con formato visible (\xHH por byte)
+                    receivedESCPOSTData = response.data.replace(/(..)/g, 'x$1');
+                    // modifica receivedESCPOSTData para que añada x a cada dos carácteres para que se vean como hex
+                    const previewHtml = generateHtmlPreview(receivedESCPOSTData);
                     $('#ticketPreviewContainer').html(previewHtml);
                     $('#printTicketButton').prop('disabled', false);
                     showModalAlert(`{{ trans('ticket-ready-to-print') }}`, 'success', 5000, 'modalPrintAlert', 'modalPrintAlertMessage');
@@ -743,7 +745,7 @@ Este segundo modal es parecido al primero pero dedicado ya al funcionamiento de 
 
     $('#printTicketButton').click(() => {
         if (receivedESCPOSTData) {
-            sendDataToUSB(receivedESCPOSTData, 'modalPrintAlert', 'modalPrintAlertMessage');
+            sendDataToUSB({type: 'hex', data: receivedESCPOSTData}, 'modalPrintAlert', 'modalPrintAlertMessage');
         } else {
             showModalAlert(`{{ trans('no-ticket-data-to-print-load-first') }}`, 'warning', 5000, 'modalPrintAlert', 'modalPrintAlertMessage');
         }

--- a/View/Modal/PrintTicketModal.html.twig
+++ b/View/Modal/PrintTicketModal.html.twig
@@ -579,7 +579,7 @@ Este segundo modal es parecido al primero pero dedicado ya al funcionamiento de 
             } else if (line.startsWith('[IMG:') && line.endsWith(']')) {
                 const url = line.substring(5, line.length - 1);
                 const safeUrl = escapeHtml(url);
-                html += `<div style=\"text-align:center; margin:8px 0;\"><img src=\"${safeUrl}\" alt=\"ticket-image\" style=\"display:inline-block; max-width:100%; image-rendering: pixelated;\"/></div>`;
+                html += `<div style=\"text-align:center; margin:8px 0;\"><img src=\"${safeUrl}\" alt=\"ticket-image\" style=\"display:inline-block; width:70%; max-width:100%; height:auto; image-rendering: pixelated;\"/></div>`;
             } else if (line.length === 0) {
                 html += '<div>&nbsp;</div>';
             } else {

--- a/XMLView/EditTicketPrinter.xml
+++ b/XMLView/EditTicketPrinter.xml
@@ -59,6 +59,9 @@
             <column name="print-logo" order="150">
                 <widget type="checkbox" fieldname="print_stored_logo"/>
             </column>
+            <column name="logo" order="155">
+                <widget type="library" fieldname="idlogo" icon="fa-solid fa-image" onclick="EditAttachedFile" accept=".gif,.jpg,.jpeg,.png"/>
+            </column>
         </group>
         <group name="header" title="header" icon="fa-solid fa-arrows-up-to-line" numcolumns="6">
             <column name="ticket-head" numcolumns="12" order="100">

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
         }
     },
     "require": {
-        "mike42/escpos-php": "^2.2"
+        "mike42/escpos-php": "^2.2",
+        "ext-gd": "*"
     }
 }


### PR DESCRIPTION
## Información general

Se han implementado bastantes cambios para convertir imágenes a imprimibles, conseguir imprimirlas y asegurar comunicación correcta entre cliente/servidor y agregada una previsualización fiel y estructurada.

## Cambios específicos:

- Se ha agregado una clase para generar imágenes imprimibles y guardarlas (si existe se sobreescribe) en public.
- Se ha implementado la propiedad 'logo' a la clase Printer para poder asignar un logo desde la biblioteca que tenga formatos soportados por la extensión gd.
- Se ha implementado al flujo de tickets el imprimir el logo de la empresa.
- Se ha modificado la previsualización de la siguiente manera:
  - Se ha agregado una propiedad de a la clase Tickets llamada 'previewbody' que contiene un texto con la estructura del ticket y metadatos para una previsualización sencilla y eficiente.
  - Se ha modificado el método `::escpos->text()` a `::text()` para así evitar repetición de código (realiza la misma tarea y agrega texto a la previsualización).
  - El resto de comandos tienen debajo otra instrucción que agrega "flags" a 'previewbody' para la previsualización.
- Se ha modificado la manera en la que qztray recibe el escpos e imprime el mismo.

## importante

Este commit va de la mano con la actualización de mc20printer debido a que al imprimir imágenes se emplean caracteres especiales, el bug se detalla mejor aquí: https://github.com/FacturaScripts/mc20printer/pull/2

También como siempre poner a prueba para ver si todo está correcto. Mis pruebas a doc han salido bien pero puede haber algo incorrecto como siempre.

## Disculpas
Finalmente, se que los cambios tienen que ser progresivos y los commits atómicos, pero este caso especial no ha sido posible separar la tarea en menores partes. Lo siento, en la próxima se intentará evitar.