### PR TITLE
Actualiza URLs de descarga de FSPrinter a v1.4.1

### DIFF
--- a/View/Tab/DownloadPrinterApp.html.twig
+++ b/View/Tab/DownloadPrinterApp.html.twig
@@ -14,25 +14,25 @@
                     </button>
                     <div class="dropdown-menu">
                         <a class="dropdown-item"
-                           href="https://github.com/FacturaScripts/tickets/releases/download/v2.9/MC20.Printer.Setup.1.4.1.exe">
+                           href="https://github.com/FacturaScripts/fsprinter/releases/download/v1.4.1/FSPrinter.1.4.1.exe">
                             <i class="fa-brands fa-windows fa-fw me-1"></i> Windows 10/11 (64 bits)
                         </a>
                         <hr class="dropdown-divider">
                         <a class="dropdown-item"
-                           href="https://github.com/FacturaScripts/tickets/releases/download/v2.9/MC20.Printer-1.4.1-arm64.dmg">
+                           href="https://github.com/FacturaScripts/fsprinter/releases/download/v1.4.1/FSPrinter-1.4.1-arm64.dmg">
                             <i class="fa-brands fa-apple fa-fw me-1"></i> Mac (.dmg)
                         </a>
                         <hr class="dropdown-divider">
                         <a class="dropdown-item"
-                           href="https://github.com/FacturaScripts/tickets/releases/download/v2.9/mc20printer_1.4.1_amd64.deb">
+                           href="https://github.com/FacturaScripts/fsprinter/releases/download/v1.4.1/fsprinter_1.4.1_amd64.deb">
                             <i class="fa-brands fa-linux fa-fw me-1"></i> Linux (.deb)
                         </a>
                         <a class="dropdown-item"
-                           href="https://github.com/FacturaScripts/tickets/releases/download/v2.9/mc20printer-1.4.1.x86_64.rpm">
+                           href="https://github.com/FacturaScripts/fsprinter/releases/download/v1.4.1/fsprinter-1.4.1.x86_64.rpm">
                             <i class="fa-brands fa-linux fa-fw me-1"></i> Linux (.rpm)
                         </a>
                         <a class="dropdown-item"
-                           href="https://github.com/FacturaScripts/tickets/releases/download/v2.9/MC20.Printer-1.4.1.AppImage">
+                           href="https://github.com/FacturaScripts/fsprinter/releases/download/v1.4.1/FSPrinter-1.4.1.AppImage">
                             <i class="fa-brands fa-linux fa-fw me-1"></i> Linux (.appImage)
                         </a>
                     </div>


### PR DESCRIPTION
Actualización automática de las URLs de descarga en DownloadPrinterApp tras publicar la release v1.4.1 de fsprinter.